### PR TITLE
#75 Refactor AnsiTreeViewTheme

### DIFF
--- a/example/treeview/empty.dart
+++ b/example/treeview/empty.dart
@@ -11,6 +11,6 @@ void main() {
       'list': <String>['This', 'is', 'AnsiX'],
       'empty_list': <String>[],
     },
-    theme: const AnsiTreeViewTheme(classTheme: TreeClassTheme(showHash: false)),
+    theme: const AnsiTreeViewTheme(classTheme: AnsiTreeClassTheme(showHash: false)),
   );
 }

--- a/lib/src/widgets/tree_view/theme.dart
+++ b/lib/src/widgets/tree_view/theme.dart
@@ -9,40 +9,40 @@ class AnsiTreeViewTheme {
     this.compact = true,
     this.sorted = false,
     this.showListItemIndex = false,
-    this.anchorTheme = const TreeAnchorTheme(),
-    this.keyTheme = const TreeNodeTheme(
+    this.anchorTheme = const AnsiTreeAnchorTheme(),
+    this.keyTheme = const AnsiTreeNodeTheme(
       textStyle: AnsiTextStyle(bold: true),
     ),
-    this.valueTheme = const TreeNodeTheme(),
-    this.classTheme = const TreeClassTheme(),
+    this.valueTheme = const AnsiTreeNodeTheme(),
+    this.classTheme = const AnsiTreeClassTheme(),
   });
 
   final bool compact;
   final bool sorted;
   final bool showListItemIndex;
-  final TreeAnchorTheme anchorTheme;
-  final TreeNodeTheme keyTheme;
-  final TreeNodeTheme valueTheme;
-  final TreeClassTheme classTheme;
+  final AnsiTreeAnchorTheme anchorTheme;
+  final AnsiTreeNodeTheme keyTheme;
+  final AnsiTreeNodeTheme valueTheme;
+  final AnsiTreeClassTheme classTheme;
 
   /// Default theme for [AnsiTreeView].
   factory AnsiTreeViewTheme.$default() {
     return AnsiTreeViewTheme(
       compact: true,
       sorted: false,
-      anchorTheme: const TreeAnchorTheme(
+      anchorTheme: const AnsiTreeAnchorTheme(
         color: AnsiColor.deepSkyBlue5,
-        boxDrawingSet: BoxDrawingSet.square,
+        style: AnsiBorderStyle.square,
       ),
-      keyTheme: const TreeNodeTheme(
+      keyTheme: const AnsiTreeNodeTheme(
         color: AnsiColor.white,
         textStyle: AnsiTextStyle(bold: true),
       ),
-      valueTheme: const TreeNodeTheme(
+      valueTheme: const AnsiTreeNodeTheme(
         color: AnsiColor.grey69,
         textStyle: AnsiTextStyle(italic: true),
       ),
-      classTheme: TreeClassTheme(
+      classTheme: AnsiTreeClassTheme(
         textTheme: AnsiTextTheme(
           style: const AnsiTextStyle(bold: true),
           padding: AnsiPadding.horizontal(2),
@@ -59,22 +59,22 @@ class AnsiTreeViewTheme {
   }
 }
 
-/// **TreeAnchorTheme**
-class TreeAnchorTheme {
+/// **AnsiTreeAnchorTheme**
+class AnsiTreeAnchorTheme {
   /// Shorthand constructor
-  const TreeAnchorTheme({
-    this.boxDrawingSet = BoxDrawingSet.square,
+  const AnsiTreeAnchorTheme({
+    this.style = AnsiBorderStyle.square,
     this.color = AnsiColor.none,
   });
 
-  final BoxDrawingSet boxDrawingSet;
+  final AnsiBorderStyle style;
   final AnsiColor color;
 }
 
-/// **TreeClassTheme**
-class TreeClassTheme {
+/// **AnsiTreeClassTheme**
+class AnsiTreeClassTheme {
   /// Shorthand constructor
-  const TreeClassTheme({
+  const AnsiTreeClassTheme({
     this.border = const AnsiBorder(),
     this.textTheme = const AnsiTextTheme(),
     this.showHash = true,
@@ -85,10 +85,10 @@ class TreeClassTheme {
   final bool showHash;
 }
 
-/// **TreeNodeTheme**
-class TreeNodeTheme {
+/// **AnsiTreeNodeTheme**
+class AnsiTreeNodeTheme {
   /// Shorthand constructor
-  const TreeNodeTheme({
+  const AnsiTreeNodeTheme({
     this.textStyle = const AnsiTextStyle(),
     this.color = AnsiColor.none,
   });

--- a/lib/src/widgets/tree_view/tree_view.dart
+++ b/lib/src/widgets/tree_view/tree_view.dart
@@ -48,10 +48,10 @@ class AnsiTreeView {
   AnsiTreeView({
     this.theme = const AnsiTreeViewTheme(),
   }) : _lineLength = theme.compact ? 2 : 4 {
-    _horizontalLine = (theme.anchorTheme.boxDrawingSet.horizontalLine * _lineLength).withForegroundColor(
+    _horizontalLine = (theme.anchorTheme.style.boxDrawingSet.horizontalLine * _lineLength).withForegroundColor(
       theme.anchorTheme.color,
     );
-    _verticalLine = theme.anchorTheme.boxDrawingSet.verticalLine.withForegroundColor(
+    _verticalLine = theme.anchorTheme.style.boxDrawingSet.verticalLine.withForegroundColor(
       theme.anchorTheme.color,
     );
   }
@@ -84,7 +84,7 @@ class AnsiTreeView {
           .replaceRange(
             prefixLength,
             prefixLength + 1,
-            theme.anchorTheme.boxDrawingSet.middleTopEdge,
+            theme.anchorTheme.style.boxDrawingSet.middleTopEdge,
           )
           .colored(foreground: theme.classTheme.border.color);
       header = <String>[
@@ -130,8 +130,9 @@ class AnsiTreeView {
   }) {
     final StringBuffer buffer = StringBuffer()
       ..write(prefix)
-      ..write(
-          isLast ? theme.anchorTheme.boxDrawingSet.bottomLeftCorner : theme.anchorTheme.boxDrawingSet.middleLeftEdge);
+      ..write(isLast
+          ? theme.anchorTheme.style.boxDrawingSet.bottomLeftCorner
+          : theme.anchorTheme.style.boxDrawingSet.middleLeftEdge);
     return buffer.toString().withForegroundColor(theme.anchorTheme.color);
   }
 

--- a/test/widgets/tree_view/tree_view_test.dart
+++ b/test/widgets/tree_view/tree_view_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('List<int>', () {
       final String actual = AnsiTreeView(
         theme: const AnsiTreeViewTheme(
-          classTheme: TreeClassTheme(showHash: false),
+          classTheme: AnsiTreeClassTheme(showHash: false),
         ),
       ).format(<int>[1, 2, 3, 4, 5]);
       expect(actual, treeViewMock1);
@@ -19,7 +19,7 @@ void main() {
     test('Map<String, dynamic>', () {
       final String actual = AnsiTreeView(
         theme: const AnsiTreeViewTheme(
-          classTheme: TreeClassTheme(showHash: false),
+          classTheme: AnsiTreeClassTheme(showHash: false),
         ),
       ).format(<String, dynamic>{'id': 12312, 'username': 'AnsiX'});
       expect(actual, treeViewMock2);
@@ -28,7 +28,7 @@ void main() {
     test('String', () {
       final String actual = AnsiTreeView(
         theme: const AnsiTreeViewTheme(
-          classTheme: TreeClassTheme(showHash: false),
+          classTheme: AnsiTreeClassTheme(showHash: false),
         ),
       ).format('This is a test message');
       expect(actual, treeViewMock3);
@@ -61,7 +61,7 @@ void main() {
       );
       final String actual = AnsiTreeView(
         theme: const AnsiTreeViewTheme(
-          classTheme: TreeClassTheme(showHash: false),
+          classTheme: AnsiTreeClassTheme(showHash: false),
         ),
       ).format(user);
       expect(actual.unformatted, treeViewMockObject);
@@ -96,7 +96,7 @@ void main() {
         theme: const AnsiTreeViewTheme(
           compact: false,
           sorted: true,
-          classTheme: TreeClassTheme(
+          classTheme: AnsiTreeClassTheme(
             showHash: false,
             border: AnsiBorder(
               type: AnsiBorderType.all,
@@ -142,7 +142,7 @@ void main() {
       };
 
       final String actual = AnsiTreeView(
-        theme: const AnsiTreeViewTheme(classTheme: TreeClassTheme(showHash: false)),
+        theme: const AnsiTreeViewTheme(classTheme: AnsiTreeClassTheme(showHash: false)),
       ).format(map);
       expect(actual.unformatted, treeviewEmptyMock);
     });


### PR DESCRIPTION
- Rename `TreeAnchorTheme` to `AnsiTreeAnchorTheme`
- Rename `TreeClassTheme` to `AnsiTreeClassTheme`
- Rename `TreeNodeTheme` to `AnsiTreeNodeTheme`
- Replace AnsiTreeAnchorTheme's `BoxDrawingSet` property with `AnsiBorderStyle`